### PR TITLE
Reduce timeout

### DIFF
--- a/src/main/java/no/fint/isiclient/FintIsiclient.java
+++ b/src/main/java/no/fint/isiclient/FintIsiclient.java
@@ -29,7 +29,7 @@ public class FintIsiclient {
     private int fetchSize = 32;
 
     @Setter
-    private int timeout = 45000;
+    private int timeout = 18000;
 
     @Setter
     private int pullMaxRetries = 50;


### PR DESCRIPTION
Present timeout sometimes causes status expired at IST, and the adapter to freeze. IST recommends 7200, but most, including VigoBAS uses 18000.